### PR TITLE
Bit encoder refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,6 +552,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_seeder"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2890aaef0aa82719a50e808de264f9484b74b442e1a3a0e5ee38243ac40bdb"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "rayon"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +629,8 @@ dependencies = [
  "pbkdf2",
  "rand",
  "rand_core",
+ "rand_pcg",
+ "rand_seeder",
  "structopt",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,5 @@ cbc = {version = "0.1.2", features = ["std"]}
 pbkdf2 = "0.11.0"
 rand_core = { version = "0.6", features = ["std"] }
 rand = "0.8.5"
+rand_pcg = "0.3.1"
+rand_seeder = "0.2.3"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,7 @@
 use std::path::PathBuf;
 use structopt::StructOpt;
+use crate::steganography::StegMethod;
+use anyhow::{Result,bail};
 
 #[derive(StructOpt)]
 #[structopt(name="🦕 Stegosaurust", about="Hide text in images, using rust.")]
@@ -16,6 +18,18 @@ pub struct Opt {
     #[structopt(short,long)]
     pub key: Option<String>,
 
+    /// Method to use for encoding (lsb,rsb)
+    #[structopt(short,long,default_value="lsb")]
+    pub method: StegMethod,
+
+    /// Seed for random significant bit encoding
+    #[structopt(short,long,required_if("method", "rsb"))]
+    pub seed: Option<String>,
+
+    /// Maximum bit to possible modify (1-4)
+    #[structopt(short="N",long,required_if("method", "rsb"))]
+    pub max_bit: Option<u8>,
+
     /// Output file, stdout if not present
     #[structopt(short,long,parse(from_os_str))]
     pub output: Option<PathBuf>,
@@ -27,6 +41,16 @@ pub struct Opt {
     /// Input image
     #[structopt(parse(from_os_str))]
     pub image: PathBuf,
+}
 
+impl Opt {
+    pub fn validate(&self) -> Result<()> {
+        if let Some(n) = self.max_bit {
+            if n < 1 || n > 4 {
+                bail!(format!("max-bit must be between 1-4. Got {}", n))
+            }
+        }
+        Ok(())
+    }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use anyhow::{Context,Result};
 
 fn main() -> Result<()> {
     let opt = cli::Opt::from_args();
+    opt.validate()?;
     run(opt).context("failed to run steganography")?;
     Ok(())
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -8,7 +8,7 @@ use image::{ImageFormat};
 use base64;
 
 use crate::cli;
-use crate::steganography::{Lsb,END,BitEncoder,Steganography};
+use crate::steganography::{Lsb,Rsb,END,BitEncoder,Steganography,StegMethod};
 use crate::crypto;
 
 pub fn run(opt: cli::Opt) -> Result<()> {
@@ -19,8 +19,17 @@ pub fn run(opt: cli::Opt) -> Result<()> {
         _ => {}
     }
 
-    let lsb = Box::new(Lsb::new());
-    let mut encoder: Box<dyn Steganography> = Box::new(BitEncoder::new(lsb));
+    // create encoder
+    let mut encoder: Box<dyn Steganography> = match opt.method {
+        StegMethod::LeastSignificantBit => {
+            let lsb = Box::new(Lsb::new());
+            Box::new(BitEncoder::new(lsb))
+        },
+        StegMethod::RandomSignificantBit => {
+            let rsb = Box::new(Rsb::new(opt.max_bit.unwrap(), &(opt.seed.unwrap())));
+            Box::new(BitEncoder::new(rsb))
+        }
+    };
 
     if opt.decode {
         let mut result = encoder.decode(&rgb8_img).context("failed to decode message from image")?;

--- a/src/run.rs
+++ b/src/run.rs
@@ -8,7 +8,7 @@ use image::{ImageFormat};
 use base64;
 
 use crate::cli;
-use crate::steganography::{Lsb,Steganography,END};
+use crate::steganography::{Lsb,END,BitEncoder,Steganography};
 use crate::crypto;
 
 pub fn run(opt: cli::Opt) -> Result<()> {
@@ -19,10 +19,11 @@ pub fn run(opt: cli::Opt) -> Result<()> {
         _ => {}
     }
 
-    let lsb = Lsb::new();
+    let lsb = Box::new(Lsb::new());
+    let encoder = BitEncoder::new(lsb);
 
     if opt.decode {
-        let mut result = lsb.decode(&rgb8_img).context("failed to decode message from image")?;
+        let mut result = encoder.decode(&rgb8_img).context("failed to decode message from image")?;
         
         // perform transformations if necessary, decode then decrypt
         if opt.base64 {
@@ -86,7 +87,7 @@ pub fn run(opt: cli::Opt) -> Result<()> {
         }
 
         // encode
-        let result = lsb.encode(&rgb8_img, &message).context("failed to encode message")?;
+        let result = encoder.encode(&rgb8_img, &message).context("failed to encode message")?;
         match opt.output {
             Some(path) => result.save(path)?,
             None => {

--- a/src/run.rs
+++ b/src/run.rs
@@ -20,7 +20,7 @@ pub fn run(opt: cli::Opt) -> Result<()> {
     }
 
     let lsb = Box::new(Lsb::new());
-    let encoder = BitEncoder::new(lsb);
+    let mut encoder: Box<dyn Steganography> = Box::new(BitEncoder::new(lsb));
 
     if opt.decode {
         let mut result = encoder.decode(&rgb8_img).context("failed to decode message from image")?;


### PR DESCRIPTION
Refactor the steganography stuff to a more generic implementation.
Introduce the idea of a general "BitEncoder" and add a random bit encoder which given a seed and max bit (up to the 4th least significant), will randomly inject the message bit at different bits in the image.
Add tests.