### PR TITLE
14 asset best fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased] - ReleaseDate
 
+## Added
+- when running `disguise` subcommand, if masking asset can't fit the file inside, all assets are tried in turn until one is found that fits, otherwise it gives up.
+
 ## Fixed
 - don't panic when attempting to decrypt a message that wasn't encrypted to begin with
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,7 +88,7 @@ pub struct EncodeOpts {
 }
 
 /// Supported steganography encoding algorithms
-#[derive(StructOpt, Debug, Clone)]
+#[derive(StructOpt, Debug, Clone, Copy)]
 pub enum StegMethod {
     /// Least significant bit encoding
     ///


### PR DESCRIPTION
Fixes #14  - asset best fit

Does so by iterating through assets until one is found that fits the data, or it loops back round to the first asset again at which point it skips the file.

# Output from Logs
Logs show one file which gets encoded but not with the first asset found, and then a file which is too large to be encoded by any asset
```
[2022-07-14T10:49:11Z DEBUG stegosaurust::run] assets/images/cat-0.jpg too small to mask tmp/1/file.pdf
[2022-07-14T10:49:14Z DEBUG stegosaurust::run] encoding tmp/1/survey.pdf with assets/images/cat-1.jpg ==> tmp/1/ZmlsZS5wZGY=.png
[2022-07-14T10:49:28Z DEBUG stegosaurust::run] assets/images/cat-2.jpg too small to mask tmp/1/example-2.png
[2022-07-14T10:49:29Z DEBUG stegosaurust::run] assets/images/cat-3.jpg too small to mask tmp/1/example-2.png
[2022-07-14T10:49:30Z DEBUG stegosaurust::run] assets/images/cat-0.jpg too small to mask tmp/1/example-2.png
[2022-07-14T10:49:33Z DEBUG stegosaurust::run] assets/images/cat-1.jpg too small to mask tmp/1/example-2.png
[2022-07-14T10:49:33Z DEBUG stegosaurust::run] no asset large enough to mask tmp/1/example-2.png. Skipping file
[jj@arch:11:49: stegosaurust] λ RUST_LOG=debug cargo run -- disguise -d tmp/1 
    Finished dev [unoptimized + debuginfo] target(s) in 0.04s
     Running `target/debug/stegosaurust disguise -d tmp/1`
[2022-07-14T10:49:56Z DEBUG stegosaurust::run] decoding tmp/1/ZmlsZS5wZGY=.png ==> tmp/1/file.pdf
[2022-07-14T10:50:22Z WARN  stegosaurust::run] error decoding original filename from "tmp/1/example-2.png": InvalidLength
```
